### PR TITLE
fix(create): accept 201 status codes

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -410,5 +410,40 @@ describe("APIClient", () => {
       expect(api.contact?.email).toBe("john.doe@example.com");
       expect(api.contact?.url).toBe("https://example.com");
     });
+    it("should handle create method with 201 response", async () => {
+      const openAPI: OpenAPI = {
+        openapi: "3.1.0",
+        servers: [{ url: "https://api.example.com" }],
+        info: { title: "Test API", version: "1.0.0", description: "Test API" },
+        paths: {
+          "/widgets": {
+            post: {
+              operationId: "CreateWidget",
+              responses: {
+                "201": {
+                  description: "Created",
+                  content: {
+                    "application/json": {
+                      schema: { $ref: "#/components/schemas/Widget" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Widget: { type: "object" },
+          },
+        },
+      };
+
+      const client = await APIClient.fromOpenAPI(openAPI);
+      const api = (client as unknown as { api: API }).api;
+      const widget = api.resources["widget"];
+      expect(widget).toBeDefined();
+      expect(widget.createMethod).toBeDefined();
+    });
   });
 });

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -49,7 +49,9 @@ export class APIClient {
         }
 
         if (pathItem.post) {
-          const response = pathItem.post.responses?.["200"];
+          const response =
+            pathItem.post.responses?.["200"] ||
+            pathItem.post.responses?.["201"];
           if (response) {
             const schema = getSchemaFromResponse(response, openAPI);
             const responseSchema = schema
@@ -112,7 +114,9 @@ export class APIClient {
         }
       } else {
         if (pathItem.post) {
-          const response = pathItem.post.responses?.["200"];
+          const response =
+            pathItem.post.responses?.["200"] ||
+            pathItem.post.responses?.["201"];
           if (response) {
             schemaRef = getSchemaFromResponse(response, openAPI);
             const supportsUserSettableCreate =


### PR DESCRIPTION
the AEPs use 201 created for a resource created. That  should be honored in addition to 200.